### PR TITLE
Add X25519Kyber Keyshare

### DIFF
--- a/src/tls_debug.rs
+++ b/src/tls_debug.rs
@@ -275,6 +275,10 @@ impl<'a> fmt::Debug for TlsExtension<'a> {
                 "TlsExtension::EncryptedServerName{{cipher: {:?}, group: {:?} ..}}",
                 ciphersuite, group
             ),
+            TlsExtension::QuicTransportParameters(ref v) => {
+                let v: Vec<_> = v.iter().map(|c| format!("{:?}", c)).collect();
+                write!(fmt, "TlsExtension::QuicTransportParameters({:?})", v)
+            }
             TlsExtension::Grease(t, data) => write!(
                 fmt,
                 "TlsExtension::Grease(0x{:x},data={:?})",

--- a/src/tls_debug.rs
+++ b/src/tls_debug.rs
@@ -268,6 +268,17 @@ impl<'a> fmt::Debug for TlsExtension<'a> {
             TlsExtension::RenegotiationInfo(data) => {
                 write!(fmt, "TlsExtension::RenegotiationInfo(data={:?})", data)
             }
+            TlsExtension::EncryptedClientHello {
+                ch_type,
+                ciphersuite,
+                config_id,
+                enc,
+                payload,
+            } => write!(
+                fmt,
+                "TlsExtension::EncryptedClientHello{{ch_type: {:?}, ciphersuite: {:?}, config_id: {:?}, enc_len: {:?}, enc: {:?}, payload_len: {:?}, payload: {:?}}}",
+                ch_type, ciphersuite, config_id, enc.len(), enc, payload.len(), payload
+            ),
             TlsExtension::EncryptedServerName {
                 ciphersuite, group, ..
             } => write!(

--- a/src/tls_ec.rs
+++ b/src/tls_ec.rs
@@ -54,6 +54,7 @@ impl debug NamedGroup {
     Ffdhe4096 = 0x102,
     Ffdhe6144 = 0x103,
     Ffdhe8192 = 0x104,
+    X25519Kyber768Draft00 = 0x6399,
     ArbitraryExplicitPrimeCurves = 0xFF01,
     ArbitraryExplicitChar2Curves = 0xFF02,
 }


### PR DESCRIPTION
Adds support for the X25519Kyber768Draft00 (0x6399) group that is common on Google Chrome QUIC Packets.